### PR TITLE
Set the correct elasticsearch client

### DIFF
--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -148,3 +148,6 @@ module Spree
     end
   end
 end
+
+# Configure client
+Spree::Product.__elasticsearch__.client =  Elasticsearch::Client.new log: true, hosts: Spree::ElasticsearchSettings.hosts


### PR DESCRIPTION
You never set the elastic search client to one using the correct hosts, therefore the settings don't really mean too much.

Something like this should be done (or include it in the class).
