### PR TITLE
Rake task update

### DIFF
--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -5,6 +5,25 @@ module Spree
     index_name Spree::ElasticsearchSettings.index
     document_type 'spree_product'
 
+    settings number_of_shards: 1,
+      number_of_replicas: 0,
+      analysis: {
+        analyzer: {
+           nGram_analyzer: {
+              type: "custom",
+              filter: ["lowercase", "asciifolding", "nGram_filter"],
+              tokenizer: "whitespace" },
+           whitespace_analyzer: {
+              type: "custom",
+              filter: ["lowercase", "asciifolding"],
+              tokenizer: "whitespace" }},
+        filter: {
+           nGram_filter: {
+              max_gram: "20",
+              min_gram: "3",
+              type: "nGram",
+              token_chars: ["letter", "digit", "punctuation", "symbol"] }}}
+
     mapping _all: {"index_analyzer" => "nGram_analyzer", "search_analyzer" => "whitespace_analyzer"} do
       indexes :name, type: 'multi_field' do
         indexes :name, type: 'string', analyzer: 'nGram_analyzer', boost: 100

--- a/lib/tasks/load_products.rake
+++ b/lib/tasks/load_products.rake
@@ -1,31 +1,11 @@
 namespace :spree_elasticsearch do
   desc "Load all products into the index."
   task :load_products => :environment do
-    unless Elasticsearch::Model.client.indices.exists index: Spree::ElasticsearchSettings.index
-      Elasticsearch::Model.client.indices.create \
-        index: Spree::ElasticsearchSettings.index,
-        body: {
-          settings: {
-            number_of_shards: 1,
-            number_of_replicas: 0,
-            analysis: {
-              analyzer: {
-                 nGram_analyzer: {
-                    type: "custom",
-                    filter: ["lowercase", "asciifolding", "nGram_filter"],
-                    tokenizer: "whitespace" },
-                 whitespace_analyzer: {
-                    type: "custom",
-                    filter: ["lowercase", "asciifolding"],
-                    tokenizer: "whitespace" }},
-              filter: {
-                 nGram_filter: {
-                    max_gram: "20",
-                    min_gram: "3",
-                    type: "nGram",
-                    token_chars: ["letter", "digit", "punctuation", "symbol"] }}}},
-          mappings: Spree::Product.mappings.to_hash }
+    if Elasticsearch::Model.client.indices.exists index: Spree::ElasticsearchSettings.index
+      Spree::Product.__elasticsearch__.import
+      puts "Products successfully loaded into Elasticsearch indices."
+    else
+      puts "No existing elasticsearch client indices found. Run 'rake spree_elasticsearch:setup_indices' and try again."
     end
-    Spree::Product.__elasticsearch__.import
   end
 end

--- a/lib/tasks/setup_indices.rake
+++ b/lib/tasks/setup_indices.rake
@@ -1,0 +1,12 @@
+namespace :spree_elasticsearch do
+  desc "Delete any existing indices and create all from scratch."
+  task :setup_indices => :environment do
+    Elasticsearch::Model.client.indices.delete index: '_all'
+    Elasticsearch::Model.client.indices.create \
+      index: Spree::ElasticsearchSettings.index,
+      body: {
+        settings: Spree::Product.settings.to_hash,
+        mappings: Spree::Product.mappings.to_hash }
+    puts "Elasticsearch indices created successfully. Please run 'rake spree_elasticsearch:load_products' to load your products into the index."
+  end
+end

--- a/lib/tasks/setup_indices.rake
+++ b/lib/tasks/setup_indices.rake
@@ -1,12 +1,20 @@
 namespace :spree_elasticsearch do
   desc "Delete any existing indices and create all from scratch."
   task :setup_indices => :environment do
-    Elasticsearch::Model.client.indices.delete index: '_all'
+
+    # delete only our index, if it exists
+    puts "Attempting to delete index: #{Spree::ElasticsearchSettings.index}"
+    if Elasticsearch::Model.client.indices.exists index: Spree::ElasticsearchSettings.index
+      puts "Deleting index: #{Spree::ElasticsearchSettings.index}"
+      Elasticsearch::Model.client.indices.delete index: Spree::ElasticsearchSettings.index
+    end
+
     Elasticsearch::Model.client.indices.create \
       index: Spree::ElasticsearchSettings.index,
       body: {
         settings: Spree::Product.settings.to_hash,
         mappings: Spree::Product.mappings.to_hash }
+    
     puts "Elasticsearch indices created successfully. Please run 'rake spree_elasticsearch:load_products' to load your products into the index."
   end
 end


### PR DESCRIPTION
Moved elasticsearch settings to the product decorator to make it easier to modify alongside the mappings. Also added a new rake task for setting up the elasticsearch indices, and took that functionality out of the load_products rake task.
