### PR TITLE
fix for "No handler for type [multi_field] declared on field" error

### DIFF
--- a/app/helpers/spree/base_helper_decorator.rb
+++ b/app/helpers/spree/base_helper_decorator.rb
@@ -3,16 +3,16 @@ module Spree
     # parses the properties facet result
     # input: Facet(name: "properties", type: "terms", body: {"terms" => [{"term" => "key1||value1", "count" => 1},{"term" => "key1||value2", "count" => 1}]}])
     # output: Facet(name: key1, type: terms, body: {"terms" => [{"term" => "value1", "count" => 1},{"term" => "value2", "count" => 1}]})
-    def expand_properties_facet_to_facet_array(facet)
+    def expand_properties_aggregation_to_aggregation_array(aggregation)
       # first step is to build a hash
       # {"property_name" => [{"term" => "value1", "count" => 1},{"term" => "value2", "count" => 1}]}}
       property_names = {}
-      facet["terms"].each do |term|
-        t = term["term"].split("||")
+      aggregation[:buckets].each do |term|
+        t = term[:key].split('||')
         property_name = t[0]
         property_value = t[1]
         # add a search_term to each term hash to allow searching on the element later on
-        property = {"term" => property_value, "count" => term["count"], "search_term" => term["term"]}
+        property = { term: property_value, count: term[:doc_count], search_term: term[:key] }
         if property_names.has_key?(property_name)
           property_names[property_name] << property
         else
@@ -24,10 +24,9 @@ module Spree
       # format: Facet(name: "property_name", type: type, body: {"terms" => [{"term" => "value1", "count" => 1},{"term" => "value2", "count" => 1}]}])
       result = {}
       property_names.each do |key,value|
-        value.sort_by!{|h| [-h["count"],h["term"].downcase]} # first sort on desc, then on term asc
+        value.sort_by!{ |value| [-value[:count], value[:term].downcase] } # first sort on desc, then on term asc
         # result << Spree::Search::Elasticsearch::Facet.new(name: key, search_name: facet.name, type: facet.type, body: {"terms" => value})
         result[key] = {
-          '_type' => facet['_type'],
           'terms' => value
         }
       end
@@ -37,19 +36,19 @@ module Spree
     # Helper method for interpreting facets from Elasticsearch. Something like a before filter.
     # Sorting, changings things, the world is your oyster
     # Input is a hash
-    def process_facets(facets)
-      new_facets = {}
+    def process_aggregations(aggregations)
+      new_aggregations = {}
       delete_keys = []
-      facets.map do |key, facet|
-        if key == "properties"
-          new_facets.merge! expand_properties_facet_to_facet_array(facet)
+      aggregations.map do |key, aggregation|
+        if key == 'properties'
+          new_aggregations.merge! expand_properties_aggregation_to_aggregation_array(aggregation)
           delete_keys << :properties
         else
-          facet
+          aggregation
         end
       end
-      delete_keys.each {|key| facets.delete(key) }
-      facets.merge! new_facets
+      delete_keys.each { |key| aggregations.delete(key) }
+      aggregations.merge! new_aggregations
     end
   end
 end

--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -6,8 +6,8 @@ module Spree
     document_type 'spree_product'
 
     mapping _all: { analyzer: 'nGram_analyzer', search_analyzer: 'whitespace_analyzer' } do
-      indexes :name, type: 'multi_field' do
-        indexes :name, type: 'string', analyzer: 'nGram_analyzer', boost: 100
+      indexes :name, type: 'text' do
+        indexes :name, type: 'text', analyzer: 'nGram_analyzer', boost: 100
         indexes :untouched, type: 'string', include_in_all: false, index: 'not_analyzed'
       end
 

--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -5,11 +5,12 @@ module Spree
     index_name Spree::ElasticsearchSettings.index
     document_type 'spree_product'
 
-    mapping _all: {"index_analyzer" => "nGram_analyzer", "search_analyzer" => "whitespace_analyzer"} do
+    mapping _all: { analyzer: 'nGram_analyzer', search_analyzer: 'whitespace_analyzer' } do
       indexes :name, type: 'multi_field' do
         indexes :name, type: 'string', analyzer: 'nGram_analyzer', boost: 100
         indexes :untouched, type: 'string', include_in_all: false, index: 'not_analyzed'
       end
+
       indexes :description, analyzer: 'snowball'
       indexes :available_on, type: 'date', format: 'dateOptionalTime', include_in_all: false
       indexes :price, type: 'double'
@@ -77,7 +78,7 @@ module Spree
       #   filter: { range: { price: { lte: , gte: } } },
       #   sort: [],
       #   from: ,
-      #   facets:
+      #   aggregations:
       # }
       def to_hash
         q = { match_all: {} }
@@ -92,31 +93,31 @@ module Spree
           # to { terms: { properties: ["key1||value_a","key1||value_b"] }
           #    { terms: { properties: ["key2||value_a"] }
           # This enforces "and" relation between different property values and "or" relation between same property values
-          properties = @properties.map {|k,v| [k].product(v)}.map do |pair|
-            and_filter << { terms: { properties: pair.map {|prop| prop.join("||")} } }
+          properties = @properties.map{ |key, value| [key].product(value) }.map do |pair|
+            and_filter << { terms: { properties: pair.map { |property| property.join('||') } } }
           end
         end
 
         sorting = case @sorting
-        when "name_asc"
-          [ {"name.untouched" => { order: "asc" }}, {"price" => { order: "asc" }}, "_score" ]
-        when "name_desc"
-          [ {"name.untouched" => { order: "desc" }}, {"price" => { order: "asc" }}, "_score" ]
-        when "price_asc"
-          [ {"price" => { order: "asc" }}, {"name.untouched" => { order: "asc" }}, "_score" ]
-        when "price_desc"
-          [ {"price" => { order: "desc" }}, {"name.untouched" => { order: "asc" }}, "_score" ]
-        when "score"
-          [ "_score", {"name.untouched" => { order: "asc" }}, {"price" => { order: "asc" }} ]
+        when 'name_asc'
+          [ { 'name.untouched' => { order: 'asc' } }, { price: { order: 'asc' } }, '_score' ]
+        when 'name_desc'
+          [ { 'name.untouched' => { order: 'desc' } }, { price: { order: 'asc' } }, '_score' ]
+        when 'price_asc'
+          [ { 'price' => { order: 'asc' } }, { 'name.untouched' => { order: 'asc' } }, '_score' ]
+        when 'price_desc'
+          [ { 'price' => { order: 'desc' } }, { 'name.untouched' => { order: 'asc' } }, '_score' ]
+        when 'score'
+          [ '_score', { 'name.untouched' => { order: 'asc' } }, { price: { order: 'asc' } } ]
         else
-          [ {"name.untouched" => { order: "asc" }}, {"price" => { order: "asc" }}, "_score" ]
+          [ { 'name.untouched' => { order: 'asc' } }, { price: { order: 'asc' } }, '_score' ]
         end
 
-        # facets
-        facets = {
-          price: { statistical: { field: "price" } },
-          properties: { terms: { field: "properties", order: "count", size: 1000000 } },
-          taxon_ids: { terms: { field: "taxon_ids", size: 1000000 } }
+        # aggregations
+        aggregations = {
+          price: { stats: { field: 'price' } },
+          properties: { terms: { field: 'properties', order: { _count: 'asc' }, size: 1000000 } },
+          taxon_ids: { terms: { field: 'taxon_ids', size: 1000000 } }
         }
 
         # basic skeleton
@@ -125,7 +126,7 @@ module Spree
           query: { filtered: {} },
           sort: sorting,
           from: from,
-          facets: facets
+          aggregations: aggregations
         }
 
         # add query and filters to filtered
@@ -133,8 +134,8 @@ module Spree
         # taxon and property filters have an effect on the facets
         and_filter << { terms: { taxon_ids: taxons } } unless taxons.empty?
         # only return products that are available
-        and_filter << { range: { available_on: { lte: "now" } } }
-        result[:query][:filtered][:filter] = { "and" => and_filter } unless and_filter.empty?
+        and_filter << { range: { available_on: { lte: 'now' } } }
+        result[:query][:filtered][:filter] = { and: and_filter } unless and_filter.empty?
 
         # add price filter outside the query because it should have no effect on facets
         if price_min && price_max && (price_min < price_max)

--- a/app/views/spree/shared/_filter_price.html.erb
+++ b/app/views/spree/shared/_filter_price.html.erb
@@ -1,14 +1,14 @@
-<fieldset class="facet">
-  <h4 class="filter"><%= facet.name %></h4>
-  <div class="facet-box">
-    <div class="slider">
-      <div class="rangeslider_top_margin"></div>
-      <input type="text" id="price" />
+<fieldset class='facet'>
+  <h4 class='filter'><%= aggregation.name %></h4>
+  <div class='facet-box'>
+    <div class='slider'>
+      <div class='rangeslider_top_margin'></div>
+      <input type='text' id='price' />
     </div>
-    <div class="slider-input">
-      <input type="text" id="price-min" name="search[price][min]" value"<%= facet["min"] %>">
+    <div class='slider-input'>
+      <input type='text' id='price-min' name='search[price][min]' value="<%= aggregation['min'] %>">
       <span>to</span>
-      <input type="text" id="price-max" name="search[price][max]" value"<%= facet["max"] %>">
+      <input type='text' id='price-max' name='search[price][max]' value="<%= aggregation['max'] %>">
     </div>
   </div>
 </fieldset>
@@ -16,22 +16,22 @@
 <% content_for :head do %>
   <script type='text/javascript'>
     $(document).ready(function(){
-      $("#price-min").change(function () {
+      $('#price-min').change(function () {
         // check if not below minimum
-        $("#price").ionRangeSlider("update", {
+        $('#price').ionRangeSlider('update', {
           from: $(this).val()
         });
       });
 
-      $("#price-max").change(function () {
+      $('#price-max').change(function () {
         // check if not above maximum
-        $("#price").ionRangeSlider("update", {
+        $('#price').ionRangeSlider('update', {
           to: $(this).val()
         });
       });
 
-      minimum = <%= (facet["min"] == facet["max"] ? (facet["min"] - 1) : facet["min"]).floor %>;
-      maximum = <%= (facet["max"] == facet["min"] ? (facet["min"] + 1) : facet["max"]).ceil %>;
+      minimum = <%= (aggregation['min'] == aggregation['max'] ? (aggregation['min'] - 1) : aggregation['min']).floor %>;
+      maximum = <%= (aggregation['max'] == aggregation['min'] ? (aggregation['min'] + 1) : aggregation['max']).ceil %>;
       min_param = minimum;
       <% if params[:search] && params[:search][:price] %>
         min_param = <%= params[:search][:price][:min] %>
@@ -41,7 +41,7 @@
         max_param = <%= params[:search][:price][:max] %>
       <% end %>
 
-      $("#price").ionRangeSlider({
+      $('#price').ionRangeSlider({
         min: minimum,
         max: maximum,
         from: min_param,
@@ -51,13 +51,13 @@
         prefix: "<%= ::Money.new(1, Spree::Config[:currency]).symbol %>",
         prettify: false,
         hasGrid: false,
-        onLoad: function(obj) { 
-          $("#price-min").val(obj.fromNumber);
-          $("#price-max").val(obj.toNumber);
+        onLoad: function(obj) {
+          $('#price-min').val(obj.fromNumber);
+          $('#price-max').val(obj.toNumber);
         },
-        onChange: function(obj) { 
-          $("#price-min").val(obj.fromNumber);
-          $("#price-max").val(obj.toNumber);
+        onChange: function(obj) {
+          $('#price-min').val(obj.fromNumber);
+          $('#price-max').val(obj.toNumber);
         }
       });
     });

--- a/app/views/spree/shared/_filter_properties.html.erb
+++ b/app/views/spree/shared/_filter_properties.html.erb
@@ -1,16 +1,16 @@
-<% facets.each do |facet_name, facet| %>
-  <fieldset class="facet">
-    <h4 class="filter"><%= facet_name %></h4>
-    <div class="facet-box">
-      <ul class="filter_choices unstyled">
-        <% facet["terms"].each do |term| %>
-        <li class="nowrap">
-          <input type="checkbox"
-                 id="<%= term["term"] %>"
-                 name="search[properties][<%= facet_name %>][]"
-                 value="<%= term["term"] %>"
-                 <%= params[:search][:properties] && params[:search][:properties][facet_name] && params[:search][:properties][facet_name].include?(term["term"]) ? "checked" : "" %> />
-          <label class="nowrap" for="<%= term["term"] %>"> <%= term["term"] %> (<%= term["count"] %>)</label>
+<% aggregations.each do |aggregation_name, aggregation| %>
+  <fieldset class='facet'>
+    <h4 class='filter'><%= aggregation_name %></h4>
+    <div class='facet-box'>
+      <ul class='filter_choices unstyled'>
+        <% aggregation[:terms].each do |term| %>
+        <li class='nowrap'>
+          <input type='checkbox'
+                 id="<%= term[:term] %>"
+                 name="search[properties][<%= aggregation_name %>][]"
+                 value="<%= term[:term] %>"
+                 <%= params[:search][:properties] && params[:search][:properties][aggregation_name] && params[:search][:properties][aggregation_name].include?(term[:term]) ? 'checked' : '' %> />
+          <label class='nowrap' for="<%= term[:term] %>"> <%= term[:term] %> (<%= term[:count] %>)</label>
         </li>
         <% end %>
       </ul>

--- a/app/views/spree/shared/_filters.html.erb
+++ b/app/views/spree/shared/_filters.html.erb
@@ -1,11 +1,11 @@
 <% unless @products.empty? %>
-  <%= form_tag '', :method => :get, :id => 'sidebar_products_search' do %>
+  <%= form_tag '', method: :get, id: 'sidebar_products_search' do %>
     <% params[:search] ||= {} %>
     <%= hidden_field_tag 'per_page', params[:per_page] %>
-    <% facets = process_facets(@products.response.response['facets']) %>
-    <%= select_tag "sorting", options_for_select({Spree.t("search_sorting.name_asc") => "name_asc", Spree.t("search_sorting.name_desc") => "name_desc", Spree.t("search_sorting.price_asc") => "price_asc", Spree.t("search_sorting.price_desc") => "price_desc", Spree.t("search_sorting.relevancy") => "score"}, params[:sorting]), :onchange => "this.form.submit();" %>
-    <%= render :partial => 'spree/shared/filter_price', :locals => { :facet => facets['price'] } %>
-    <%= render :partial => 'spree/shared/filter_properties', :locals => { :facets => facets.select {|key,facet| ((key != "price") && (key != "taxon_ids")) && (facet['_type'] == 'terms')} || [] } %>
-    <%= submit_tag Spree.t(:search), :name => nil %>
+    <% aggregations = process_aggregations(@products.response.response['aggregations']) %>
+    <%= select_tag 'sorting', options_for_select({ Spree.t('search_sorting.name_asc') => 'name_asc', Spree.t('search_sorting.name_desc') => 'name_desc', Spree.t('search_sorting.price_asc') => 'price_asc', Spree.t('search_sorting.price_desc') => 'price_desc', Spree.t('search_sorting.relevancy') => 'score' }, params[:sorting]), onchange: 'this.form.submit();' %>
+    <%= render 'spree/shared/filter_price', aggregation: aggregations['price'] %>
+    <%= render 'spree/shared/filter_properties', aggregations: aggregations.select { |key, aggregation| ((key != 'price') && (key != 'taxon_ids')) } || [] %>
+    <%= submit_tag Spree.t(:search), name: nil %>
   <% end %>
 <% end %>

--- a/spec/models/products_spec.rb
+++ b/spec/models/products_spec.rb
@@ -6,13 +6,15 @@ module Spree
     let(:a_product) { create(:product) }
     let(:another_product) { create(:product) }
 
-    before(:each) do
+    before do
       # for clean testing, delete index, create new one and create/update mapping
       Product.delete_all
       client = Elasticsearch::Client.new log: true, hosts: ElasticsearchSettings.hosts
+
       if Elasticsearch::Model.client.indices.exists index: Spree::ElasticsearchSettings.index
         client.indices.delete index: ElasticsearchSettings.index
       end
+
       client.indices.create \
         index: ElasticsearchSettings.index,
         body: {
@@ -22,19 +24,19 @@ module Spree
             analysis: {
               analyzer: {
                 nGram_analyzer: {
-                  type: "custom",
-                  filter: ["lowercase", "asciifolding", "nGram_filter"],
-                  tokenizer: "whitespace" },
+                  type: 'custom',
+                  filter: %w(lowercase asciifolding nGram_filter),
+                  tokenizer: 'whitespace' },
                 whitespace_analyzer: {
-                  type: "custom",
-                  filter: ["lowercase", "asciifolding"],
-                  tokenizer: "whitespace" }},
+                  type: 'custom',
+                  filter: %w(lowercase asciifolding),
+                  tokenizer: 'whitespace' }},
               filter: {
                 nGram_filter: {
-                  max_gram: "20",
-                  min_gram: "3",
-                  type: "nGram",
-                  token_chars: ["letter", "digit", "punctuation", "symbol"]
+                  max_gram: '20',
+                  min_gram: '3',
+                  type: 'nGram',
+                  token_chars: %w(letter digit punctuation symbol)
                 }
               }
             }
@@ -43,160 +45,199 @@ module Spree
         }
     end
 
-    context "#index" do
-      it "updates an existing product in the index" do
-        a_product.name = "updated name"
-        result = a_product.__elasticsearch__.index_document
-        result['_version'].should == 2
-        product_from_index = Product.get(a_product.id)
-        product_from_index.name.should == 'updated name'
+    context '#index' do
+      before { a_product.name = 'updated name' }
+
+      it 'updates an existing product in the index' do
+        expect(a_product.__elasticsearch__.index_document['_version']).to eq 2
+        expect(Product.get(a_product.id).name).to eq 'updated name'
       end
     end
 
     context 'get' do
-      it "retrieves a product form the index" do
-        product_from_index = Product.get(a_product.id)
-        product_from_index.name.should == a_product.name
+      subject { Product.get(a_product.id).name }
+
+      it { is_expected.to eq a_product.name }
+    end
+
+    describe 'search' do
+      context 'retrieves a product based on name' do
+        before do
+          another_product.name = 'Foobar'
+          another_product.__elasticsearch__.index_document
+          Product.__elasticsearch__.refresh_index!
+        end
+
+        let(:products) do
+          Product.__elasticsearch__.search(Spree::Product::ElasticsearchQuery.new(query: another_product.name))
+        end
+
+        it { expect(products.results.total).to eq 1 }
+        it { expect(products.results.any?{ |product| product.name == another_product.name }).to be_truthy }
+      end
+
+      context 'retrieves products based on part of the name' do
+        before do
+          a_product.name = 'Product 1'
+          another_product.name = 'Product 2'
+          a_product.__elasticsearch__.index_document
+          another_product.__elasticsearch__.index_document
+          Product.__elasticsearch__.refresh_index!
+        end
+
+        let(:products) { Product.__elasticsearch__.search(Spree::Product::ElasticsearchQuery.new(query: 'Product')) }
+
+        it { expect(products.results.total).to eq 2 }
+        it { expect(products.results.any?{ |product| product.name == a_product.name }).to be_truthy }
+        it { expect(products.results.any?{ |product| product.name == another_product.name }).to be_truthy }
+      end
+
+      context 'retrieves products default sorted on name' do
+        before do
+          a_product.name = 'Product 1'
+          a_product.__elasticsearch__.index_document
+          another_product.name = 'Product 2'
+          another_product.__elasticsearch__.index_document
+          Product.__elasticsearch__.refresh_index!
+        end
+
+        let(:products) { Product.__elasticsearch__.search(Spree::Product::ElasticsearchQuery.new) }
+
+        it { expect(products.results.total).to eq 2 }
+        it { expect(products.results.to_a[0].name).to eq a_product.name }
+        it { expect(products.results.to_a[1].name).to eq another_product.name }
+      end
+
+      context 'filters products based on price' do
+        before do
+          a_product.price = 1
+          a_product.__elasticsearch__.index_document
+          another_product.price = 3
+          another_product.__elasticsearch__.index_document
+          Product.__elasticsearch__.refresh_index!
+        end
+
+        let(:products) do
+          Product.__elasticsearch__.search(Spree::Product::ElasticsearchQuery.new(price_min: 2, price_max: 4))
+        end
+
+        it { expect(products.results.total).to eq 1 }
+        it { expect(products.results.to_a[0].name).to eq another_product.name }
+      end
+
+      context 'ignores price filter when price_min is greater than price_max' do
+        before do
+          a_product.price = 1
+          a_product.__elasticsearch__.index_document
+          another_product.price = 3
+          another_product.__elasticsearch__.index_document
+          Product.__elasticsearch__.refresh_index!
+        end
+
+        let(:products) do
+          Product.__elasticsearch__.search(Spree::Product::ElasticsearchQuery.new(price_min: 4, price_max: 2))
+        end
+
+        it { expect(products.results.total).to eq 2 }
+      end
+
+      context 'ignores price filter when price_min and/or price_max is nil' do
+        before do
+          a_product.price = 1
+          a_product.__elasticsearch__.index_document
+          another_product.price = 3
+          another_product.__elasticsearch__.index_document
+          Product.__elasticsearch__.refresh_index!
+        end
+
+        let(:products_min_price) do
+          Product.__elasticsearch__.search(Spree::Product::ElasticsearchQuery.new(price_min: 2))
+        end
+        let(:products_max_price) do
+          Product.__elasticsearch__.search(Spree::Product::ElasticsearchQuery.new(price_max: 2))
+        end
+        let(:products) do
+          Product.__elasticsearch__.search(Spree::Product::ElasticsearchQuery.new(price_min: nil, price_max: nil))
+        end
+
+        it { expect(products_min_price.results.total).to eq 2 }
+        it { expect(products_max_price.results.total).to eq 2 }
+        it { expect(products.results.total).to eq 2 }
+      end
+
+      describe 'properties' do
+        let(:product) { Product.find(a_product.id) }
+
+        subject { products.results }
+
+        context 'allows searching on property' do
+          before do
+            a_product.set_property('the_prop', 'a_value')
+            product.save
+            Product.__elasticsearch__.refresh_index!
+          end
+
+
+          let(:products) do
+            Product.__elasticsearch__.search(
+              Spree::Product::ElasticsearchQuery.new(properties: { the_prop: %w(a_value b_value) })
+            )
+          end
+
+          it { expect(subject.count).to eq 1 }
+          it { expect(subject.to_a[0].name).to eq product.name }
+        end
+
+        context 'allows searching on different property values (OR relation)' do
+          before do
+            a_product.set_property('the_prop', 'a_value')
+            another_product.set_property('the_prop', 'b_value')
+            product_one.save
+            product_two.save
+            Product.__elasticsearch__.refresh_index!
+          end
+
+          let(:product_one) { Product.find(a_product.id) }
+          let(:product_two) { Product.find(another_product.id) }
+
+          let(:products) do
+            Product.__elasticsearch__.search(
+              Spree::Product::ElasticsearchQuery.new(properties: { the_prop: %w(a_value b_value) })
+            )
+          end
+
+          it { expect(subject.count).to eq 2 }
+          it { expect(subject.to_a.find { |product| product.name == product_one.name }).to_not be_nil }
+          it { expect(subject.to_a.find { |product| product.name == product_two.name }).to_not be_nil }
+        end
+
+        context 'allows searching on different properties (AND relation)' do
+          before do
+            a_product.set_property('the_prop', 'a_value')
+            a_product.set_property('another_prop', 'a_value')
+            product.save
+            another_product.set_property('the_prop', 'a_value')
+            another_product.set_property('another_prop', 'b_value')
+            Product.find(another_product.id).save
+            Product.__elasticsearch__.refresh_index!
+          end
+
+          let(:products) do
+            Product.__elasticsearch__.search(
+              Spree::Product::ElasticsearchQuery.new(properties: { the_prop: ['a_value'], another_prop: ['a_value'] })
+            )
+          end
+
+          it { expect(subject.count).to eq 1 }
+          it { expect(subject.to_a[0].name).to eq product.name }
+        end
       end
     end
 
-    context 'search' do
-      it "retrieves a product based on name" do
-        another_product.name = "Foobar"
-        another_product.__elasticsearch__.index_document
-        sleep 3 # allow some time for elasticsearch
-        products = Product.__elasticsearch__.search(
-          Spree::Product::ElasticsearchQuery.new(query: another_product.name)
-        )
-        # products = Product.__elasticsearch__.search(query: another_product.name)
-        products.results.total.should == 1
-        products.results.any?{ |p| p.name == another_product.name }.should be_true
-      end
+    context 'document_type returns the name of the class' do
+      subject { Product.document_type }
 
-      it "retrieves products based on part of the name" do
-        a_product.name = "Product 1"
-        another_product.name = "Product 2"
-        a_product.__elasticsearch__.index_document
-        another_product.__elasticsearch__.index_document
-        sleep 3 # allow some time for elasticsearch
-        products = Product.__elasticsearch__.search(
-          Spree::Product::ElasticsearchQuery.new(query: 'Product')
-        )
-        products.results.total.should == 2
-        products.results.any?{ |p| p.name == a_product.name }.should be_true
-        products.results.any?{ |p| p.name == another_product.name }.should be_true
-      end
-
-      it "retrieves products default sorted on name" do
-        a_product.name = "Product 1"
-        a_product.__elasticsearch__.index_document
-        another_product.name = "Product 2"
-        another_product.__elasticsearch__.index_document
-        sleep 3 # allow some time for elasticsearch
-        products = Product.__elasticsearch__.search(
-          Spree::Product::ElasticsearchQuery.new
-        )
-        products.results.total.should == 2
-        products.results.to_a[0].name.should == a_product.name
-        products.results.to_a[1].name.should == another_product.name
-      end
-
-      it "filters products based on price" do
-        a_product.price = 1
-        a_product.__elasticsearch__.index_document
-        another_product.price = 3
-        another_product.__elasticsearch__.index_document
-        sleep 3 # allow some time for elasticsearch
-        products = Product.__elasticsearch__.search(
-          Spree::Product::ElasticsearchQuery.new(price_min: 2, price_max: 4)
-        )
-        products.results.total.should == 1
-        products.results.to_a[0].name.should == another_product.name
-      end
-
-      it "ignores price filter when price_min is greater than price_max" do
-        a_product.price = 1
-        a_product.__elasticsearch__.index_document
-        another_product.price = 3
-        another_product.__elasticsearch__.index_document
-        sleep 3 # allow some time for elasticsearch
-        products = Product.__elasticsearch__.search(
-          Spree::Product::ElasticsearchQuery.new(price_min: 4, price_max: 2)
-        )
-        products.results.total.should == 2
-      end
-
-      it "ignores price filter when price_min and/or price_max is nil" do
-        a_product.price = 1
-        a_product.__elasticsearch__.index_document
-        another_product.price = 3
-        another_product.__elasticsearch__.index_document
-        sleep 3 # allow some time for elasticsearch
-        products = Product.__elasticsearch__.search(
-          Spree::Product::ElasticsearchQuery.new(price_min: 2)
-        )
-        products.results.total.should == 2
-        products = Product.__elasticsearch__.search(
-          Spree::Product::ElasticsearchQuery.new(price_max: 2)
-        )
-        products.results.total.should == 2
-        products = Product.__elasticsearch__.search(
-          Spree::Product::ElasticsearchQuery.new(price_min: nil, price_max: nil)
-        )
-        products.results.total.should == 2
-      end
-
-      context 'properties' do
-        it "allows searching on property" do
-          a_product.set_property('the_prop', 'a_value')
-          product = Product.find(a_product.id)
-          product.save
-          sleep 3 # allow some time for elasticsearch
-          products = Product.__elasticsearch__.search(
-            Spree::Product::ElasticsearchQuery.new(properties: { 'the_prop' => ['a_value', 'b_value'] })
-          )
-          products.results.count.should == 1
-          products.results.to_a[0].name.should == product.name
-        end
-
-        it "allows searching on different property values (OR relation)" do
-          a_product.set_property('the_prop', 'a_value')
-          product_one = Product.find(a_product.id)
-          product_one.save
-          another_product.set_property('the_prop', 'b_value')
-          product_two = Product.find(another_product.id)
-          product_two.save
-          sleep 3 # allow some time for elasticsearch
-          products = Product.__elasticsearch__.search(
-            Spree::Product::ElasticsearchQuery.new(properties: { 'the_prop' => ['a_value', 'b_value'] })
-          )
-          products.results.count.should == 2
-          products.results.to_a.find {|p| p.name == product_one.name}.should_not be_nil
-          products.results.to_a.find {|p| p.name == product_two.name}.should_not be_nil
-        end
-
-        it "allows searching on different properties (AND relation)" do
-          a_product.set_property('the_prop', 'a_value')
-          a_product.set_property('another_prop', 'a_value')
-          product = Product.find(a_product.id)
-          product.save
-          another_product.set_property('the_prop', 'a_value')
-          another_product.set_property('another_prop', 'b_value')
-          Product.find(another_product.id).save
-          sleep 3 # allow some time for elasticsearch
-          products = Product.__elasticsearch__.search(
-            Spree::Product::ElasticsearchQuery.new(properties: { 'the_prop' => ['a_value'], 'another_prop' => ['a_value'] })
-          )
-          products.results.count.should == 1
-          products.results.to_a[0].name.should == product.name
-        end
-      end
-    end
-
-    context 'document_type' do
-      it 'returns the name of the class' do
-        Product.document_type.should == 'spree_product'
-      end
+      it { is_expected.to eq 'spree_product' }
     end
   end
 end


### PR DESCRIPTION
Changing the type from multi_field to 'text'. As multi_field is deprecated in Elastic Search.

Fixes #39 
